### PR TITLE
Point the RSS link to "/feed.xml"

### DIFF
--- a/templates/layout.jade
+++ b/templates/layout.jade
@@ -6,7 +6,7 @@ html(lang='en')
       meta(http-equiv='X-UA-Compatible', content='IE=edge,chrome=1')
       meta(name='viewport', content='width=device-width')
       
-      link(rel='alternate', href=locals.url+'/feed.xml', type='application/rss+xml', title=locals.description)
+      link(rel='alternate', href='/feed.xml', type='application/rss+xml', title=locals.description)
 
       //- link(rel='stylesheet', href='http://fonts.googleapis.com/css?family=Lora:400,700,400italic,700italic|Anonymous+Pro:400,700,400italic,700italic|Merriweather:400,700,300')
       //- link(href='http://fonts.googleapis.com/css?family=Muli:300,400,300italic,400italic', rel='stylesheet', type='text/css')


### PR DESCRIPTION
Currently, it renders to `http://localhost:8080/feed.xml` on the generated website. This points it at the same type of absolute path as is used by `style.css`.

(Also, it appears that Github added a blank line to the bottom of the file. Sorry!)
